### PR TITLE
fix(build): allow symfony/runtime composer plugin

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -51,6 +51,7 @@
             "drupal/core-project-message": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true,
+            "symfony/runtime": true,
             "tbachert/spi": true
         },
         "sort-packages": true


### PR DESCRIPTION
## Problem

`app-drupal` has not published a successful build since **2026-07-01**. Every nightly run since 2026-07-02 has failed at the same step:

```
In PluginManager.php line 821:
  symfony/runtime contains a Composer plugin which is blocked by your allow-plugins config.
```

Verified identical on runs from 2026-07-02, 2026-07-22, 2026-08-03, 2026-08-04 and a manual dispatch today. drush pulls in `symfony/runtime`; no lock file is committed, so every build resolves dependencies fresh and hits the blocked plugin.

Net effect: `ghcr.io/quantcdn-templates/app-drupal:latest` is ~34 days stale, and the workflow has been failing silently.

## Fix

Add `symfony/runtime` to `config.allow-plugins` in `src/composer.json` — the resolution the composer error itself recommends.

## Verification

Built locally for linux/amd64 against the current base image: `composer install` completes and the image builds through all 14 stages.

## Context

This also unblocks pickup of the postfix fix in `app-apache-php` ([c1179d0](https://github.com/quantcdn-templates/app-apache-php/commit/c1179d0), now on `main` and published to `:latest`), which stops cron/exec tasks hanging forever in a `postdrop: mail_queue_enter` retry loop. Confirmed it carries through into an app-drupal image built from this branch:

```
-rwxr-sr-x 1 root postdrop  /usr/sbin/postdrop
drwx-wx--- 1 postfix postdrop  /var/spool/postfix/maildrop
# mail() as www-data via the cron path (no entrypoint scripts):
bool(true)   exit=0   (previously: 10s retry loop, forever)
```

Worth a follow-up: this workflow failed nightly for a month with no alert.