### PR TITLE
ci: raise an issue when the image publish fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,3 +224,70 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.tags.outputs.tags }}" | tr ',' '\n' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  # Unattended runs (nightly schedule, push to main) have no one watching them.
+  # Without this, a broken publish just fails quietly and :latest goes stale --
+  # which is exactly what happened between 2026-07-02 and 2026-08-04.
+  notify:
+    if: always() && github.repository_owner == 'quantcdn-templates' && github.event_name != 'workflow_dispatch'
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Open or update the build-failure issue
+        if: needs.build-and-push.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = 'CI: image publish is failing';
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `Run [\`${context.runId}\`](${run}) failed on \`${context.eventName}\` (${context.sha.slice(0, 7)}).`,
+              '',
+              'While this is failing, `ghcr.io/quantcdn-templates/app-drupal:latest` stops moving',
+              'and stays pinned to the last successful build.',
+            ].join('\n');
+
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open',
+            });
+            const existing = open.find(i => !i.pull_request && i.title === marker);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.number, body,
+              });
+              core.notice(`Commented on existing issue #${existing.number}`);
+            } else {
+              const { data } = await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: marker, body,
+              });
+              core.notice(`Opened issue #${data.number}`);
+            }
+
+      - name: Close the build-failure issue once publishing recovers
+        if: needs.build-and-push.result == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = 'CI: image publish is failing';
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open',
+            });
+            const existing = open.find(i => !i.pull_request && i.title === marker);
+            if (!existing) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number,
+              body: `Publishing recovered in run [\`${context.runId}\`](${run}). Closing.`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: existing.number, state: 'closed',
+            });


### PR DESCRIPTION
## Problem

The nightly publish failed **every night from 2026-07-02 to 2026-08-04** and nothing surfaced it. `ghcr.io/quantcdn-templates/app-drupal:latest` sat 34 days stale while every run went red in a tab nobody opens.

The build fix is #69. This PR fixes the reason it went unnoticed for a month.

## Change

A `notify` job that runs after `build-and-push` on unattended events only (nightly `schedule`, `push` to main/develop/tags — not `workflow_dispatch`, which someone is already watching):

- **on failure** — open a single tracking issue titled `CI: image publish is failing`, or comment on it if already open, so a month of failures is one issue with N comments rather than N issues.
- **on success** — comment and close that issue, so it self-heals and won't linger once publishing recovers.

Uses `actions/github-script` and the default `GITHUB_TOKEN` with `issues: write` — no new secrets, no external service.

## Verification

`ci.yml` parses; `notify` resolves with `needs: build-and-push`, `permissions: {issues: write}`, and both steps correctly gated on `needs.build-and-push.result`. The failure path can't be exercised without a red build on main — it will prove itself on the first nightly run after #69 lands.

## Scope

app-drupal only. The sibling templates (app-wordpress, app-laravel, app-symfony, app-statamic, app-craft-cms, app-drupal-cms) have no failure notification either and are worth the same treatment, plus a check on whether their `:latest` has gone stale the same way.